### PR TITLE
Added support for instance profile credentials

### DIFF
--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AuthType.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AuthType.cs
@@ -1,0 +1,9 @@
+﻿
+namespace Elasticsearch.Net.Aws
+{
+    internal enum AuthType
+    {
+        AccessKey,
+        InstanceProfile,
+    }
+}

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Net;
 using Elasticsearch.Net.Connection;
 using Elasticsearch.Net.Connection.Configuration;
@@ -13,27 +12,45 @@ namespace Elasticsearch.Net.Aws
     {
         readonly string _accessKey;
         readonly string _secretKey;
+        readonly string _token;
         readonly string _region;
 
         /// <summary>
-        /// Initializes a new instance of the AwsHttpConnection class.
+        /// Initializes a new instance of the AwsHttpConnection class with the specified AccessKey, SecretKey and Token.
         /// </summary>
         /// <param name="settings">The NEST/Elasticsearch.Net settings.</param>
         /// <param name="awsSettings">AWS specific settings required for signing requests.</param>
         public AwsHttpConnection(IConnectionConfigurationValues settings, AwsSettings awsSettings) : base(settings)
         {
             if (awsSettings == null) throw new ArgumentNullException("awsSettings");
+            if (string.IsNullOrWhiteSpace(awsSettings.AccessKey)) throw new ArgumentException("awsSettings.AccessKey is invalid.", "awsSettings");
             if (string.IsNullOrWhiteSpace(awsSettings.SecretKey)) throw new ArgumentException("awsSettings.SecretKey is invalid.", "awsSettings");
             if (string.IsNullOrWhiteSpace(awsSettings.Region)) throw new ArgumentException("awsSettings.Region is invalid.", "awsSettings");
             _accessKey = awsSettings.AccessKey;
             _secretKey = awsSettings.SecretKey;
+            _token = awsSettings.Token;
             _region = awsSettings.Region.ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AwsHttpConnection class with info from the Instance Profile service
+        /// </summary>
+        /// <param name="settings">The NEST/Elasticsearch.Net settings.</param>
+        public AwsHttpConnection(IConnectionConfigurationValues settings, string region) : base(settings)
+        {
+            var credentials = InstanceProfileService.GetCredentials();
+            if (credentials == null) throw new Exception("Unable to retrieve session credentials from instance profile service");
+
+            _accessKey = credentials.AccessKeyId;
+            _secretKey = credentials.SecretAccessKey;
+            _token = credentials.Token;
+            _region = region.ToLowerInvariant();
         }
 
         protected override HttpWebRequest CreateHttpWebRequest(Uri uri, string method, byte[] data, IRequestConfiguration requestSpecificConfig)
         {
             var request = base.CreateHttpWebRequest(uri, method, data, requestSpecificConfig);
-            SignV4Util.SignRequest(request, data, _accessKey, _secretKey, _region, "es");
+            SignV4Util.SignRequest(request, data, _accessKey, _secretKey, _token, _region, "es");
             return request;
         }
     }

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsSettings.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsSettings.cs
@@ -20,8 +20,14 @@ namespace Elasticsearch.Net.Aws
 
         /// <summary>
         /// Gets or sets the AWS secret key. e.g. wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY
-        /// Required.
+        ///  Required.
         /// </summary>
         public string SecretKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AWS session token. Optional.
+        /// </summary>
+        public string Token { get; set; }
+
     }
 }

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.csproj
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.csproj
@@ -34,10 +34,6 @@
       <HintPath>..\packages\Elasticsearch.Net.1.7.1\lib\net45\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
@@ -49,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AuthType.cs" />
     <Compile Include="AwsHttpConnection.cs" />
     <Compile Include="AwsSettings.cs" />
     <Compile Include="InstanceProfileCredentials.cs" />

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.csproj
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.csproj
@@ -34,9 +34,14 @@
       <HintPath>..\packages\Elasticsearch.Net.1.7.1\lib\net45\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -46,6 +51,8 @@
   <ItemGroup>
     <Compile Include="AwsHttpConnection.cs" />
     <Compile Include="AwsSettings.cs" />
+    <Compile Include="InstanceProfileCredentials.cs" />
+    <Compile Include="InstanceProfileService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SignV4Util.cs" />
     <Compile Include="StringUtil.cs" />

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/InstanceProfileCredentials.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/InstanceProfileCredentials.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Elasticsearch.Net.Aws
+{
+    public class InstanceProfileCredentials
+    {
+        public string Code { get; set; }
+        public DateTime LastUpdated { get; set; }
+        public string Type { get; set; }
+        public string AccessKeyId { get; set; }
+        public string SecretAccessKey { get; set; }
+        public string Token { get; set; }
+        public DateTime Expiration { get; set; }
+    }
+}

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/InstanceProfileService.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/InstanceProfileService.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Web.Script.Serialization;
+
+namespace Elasticsearch.Net.Aws
+{
+    public static class InstanceProfileService
+    {
+        private static readonly string[] AliasSeparators = { "<br/>" };
+        private const string Server = "http://169.254.169.254";
+        private const string RolesPath = "/latest/meta-data/iam/security-credentials/";
+        private const string SuccessCode = "Success";
+        private static readonly JavaScriptSerializer CredentialSerializer = new JavaScriptSerializer();
+        private static InstanceProfileCredentials _cachedCredentials;
+        private static readonly object CacheLock = new object();
+
+        public static InstanceProfileCredentials GetCredentials()
+        {
+            var cachedCredentials = GetCachedCredentials();
+            if (cachedCredentials != null)
+                return cachedCredentials;
+
+            lock (CacheLock)
+            {
+                if (GetCachedCredentials() == null)
+                {
+                    var role = GetFirstRole();
+                    var json = GetContents(new Uri(Server + RolesPath + role));
+                    var credentials = CredentialSerializer.Deserialize<InstanceProfileCredentials>(json);
+
+                    if (credentials.Code != SuccessCode)
+                        return null;
+
+                    _cachedCredentials = cachedCredentials = credentials;
+
+                }
+            }
+
+            return cachedCredentials;
+        }
+
+        private static InstanceProfileCredentials GetCachedCredentials()
+        {
+            if (_cachedCredentials != null)
+            {
+                if (_cachedCredentials.Expiration > DateTime.Now.ToUniversalTime().AddMinutes(15))
+                {
+                    return _cachedCredentials;
+                }
+            }
+            return null;
+        }
+
+        private static string GetFirstRole()
+        {
+            var roles = GetAvailableRoles();
+            foreach (var role in roles)
+            {
+                return role;
+            }
+
+            // no roles found
+            throw new InvalidOperationException("No roles found");
+        }
+
+        private static IEnumerable<string> GetAvailableRoles()
+        {
+            var allAliases = GetContents(new Uri(Server + RolesPath));
+            if (string.IsNullOrEmpty(allAliases))
+                yield break;
+
+            var parts = allAliases.Split(AliasSeparators, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var part in parts)
+            {
+                var trim = part.Trim();
+                if (!string.IsNullOrEmpty(trim))
+                    yield return trim;
+            }
+        }
+
+        private static string GetContents(Uri uri)
+        {
+            try
+            {
+                var request = WebRequest.Create(uri) as HttpWebRequest;
+                var asyncResult = request.BeginGetResponse(null, null);
+                using (var response = request.EndGetResponse(asyncResult) as HttpWebResponse)
+                using (var reader = new StreamReader(response.GetResponseStream()))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+            catch (WebException)
+            {
+                throw new Exception("Unable to reach credentials server");
+            }
+        }
+
+    }
+}

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/InstanceProfileService.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/InstanceProfileService.cs
@@ -6,7 +6,7 @@ using System.Web.Script.Serialization;
 
 namespace Elasticsearch.Net.Aws
 {
-    public static class InstanceProfileService
+    internal static class InstanceProfileService
     {
         private static readonly string[] AliasSeparators = { "<br/>" };
         private const string Server = "http://169.254.169.254";
@@ -16,7 +16,7 @@ namespace Elasticsearch.Net.Aws
         private static InstanceProfileCredentials _cachedCredentials;
         private static readonly object CacheLock = new object();
 
-        public static InstanceProfileCredentials GetCredentials()
+        internal static InstanceProfileCredentials GetCredentials()
         {
             var cachedCredentials = GetCachedCredentials();
             if (cachedCredentials != null)
@@ -33,12 +33,12 @@ namespace Elasticsearch.Net.Aws
                     if (credentials.Code != SuccessCode)
                         return null;
 
-                    _cachedCredentials = cachedCredentials = credentials;
+                    _cachedCredentials = credentials;
 
                 }
             }
 
-            return cachedCredentials;
+            return GetCachedCredentials();
         }
 
         private static InstanceProfileCredentials GetCachedCredentials()
@@ -85,8 +85,7 @@ namespace Elasticsearch.Net.Aws
             try
             {
                 var request = WebRequest.Create(uri) as HttpWebRequest;
-                var asyncResult = request.BeginGetResponse(null, null);
-                using (var response = request.EndGetResponse(asyncResult) as HttpWebResponse)
+                using (var response = request.GetResponse() as HttpWebResponse)
                 using (var reader = new StreamReader(response.GetResponseStream()))
                 {
                     return reader.ReadToEnd();

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/packages.config
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Elasticsearch.Net" version="1.7.1" targetFramework="net45" />
+  <package id="NUnit" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/src/Elasticsearch.Net.Aws/IntegrationTests/IntegrationTests.csproj
+++ b/src/Elasticsearch.Net.Aws/IntegrationTests/IntegrationTests.csproj
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Elasticsearch.Net.Aws/IntegrationTests/SetUpFixture.cs
+++ b/src/Elasticsearch.Net.Aws/IntegrationTests/SetUpFixture.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Web.Helpers;
+using System.Web.Script.Serialization;
 using Elasticsearch.Net.Aws;
 using NUnit.Framework;
 
@@ -15,13 +13,15 @@ namespace IntegrationTests
         public void SetUp()
         {
             var json = File.ReadAllText("TargetConfig.json").Trim();
-            dynamic config = Json.Decode(json);
-            TestConfig.Endpoint = config.endpoint;
+            var serializer = new JavaScriptSerializer();
+            var config =serializer.Deserialize<Dictionary<string, string>>(json);
+
+            TestConfig.Endpoint = config["endpoint"];
             TestConfig.AwsSettings = new AwsSettings
             {
-                AccessKey = config.accessKey,
-                SecretKey = config.secretKey,
-                Region = config.region,
+                AccessKey = config["accessKey"],
+                SecretKey = config["secretKey"],
+                Region = config["region"],
             };
         }
     }

--- a/src/Elasticsearch.Net.Aws/Tests/InstanceProfileTests.cs
+++ b/src/Elasticsearch.Net.Aws/Tests/InstanceProfileTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+using Elasticsearch.Net.Aws;
+using NUnit.Framework;
+
+namespace Tests
+{
+    [TestFixture]
+    public class InstanceProfileTests
+    {
+        [Test]
+        public void GetCredentials_should_return_valid_credentials()
+        {
+            var credentials = InstanceProfileService.GetCredentials();
+
+            Trace.Write($"AccessKeyId: {credentials.AccessKeyId}");
+            Assert.IsNotNullOrEmpty(credentials.AccessKeyId);
+
+            Trace.Write($"SecretAccessKey: {credentials.SecretAccessKey}");
+            Assert.IsNotNullOrEmpty(credentials.SecretAccessKey);
+
+            Trace.Write($"Token: {credentials.Token}");
+            Assert.IsNotNullOrEmpty(credentials.Token);
+        }
+    }
+}

--- a/src/Elasticsearch.Net.Aws/Tests/InstanceProfileTests.cs
+++ b/src/Elasticsearch.Net.Aws/Tests/InstanceProfileTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using Elasticsearch.Net.Aws;
 using NUnit.Framework;
 
@@ -12,13 +13,13 @@ namespace Tests
         {
             var credentials = InstanceProfileService.GetCredentials();
 
-            Trace.Write($"AccessKeyId: {credentials.AccessKeyId}");
+            Trace.Write(String.Format("AccessKeyId: {0}", credentials.AccessKeyId));
             Assert.IsNotNullOrEmpty(credentials.AccessKeyId);
 
-            Trace.Write($"SecretAccessKey: {credentials.SecretAccessKey}");
+            Trace.Write(String.Format("SecretAccessKey: {0}", credentials.SecretAccessKey));
             Assert.IsNotNullOrEmpty(credentials.SecretAccessKey);
 
-            Trace.Write($"Token: {credentials.Token}");
+            Trace.Write(String.Format("Token: {0}", credentials.Token));
             Assert.IsNotNullOrEmpty(credentials.Token);
         }
     }

--- a/src/Elasticsearch.Net.Aws/Tests/SignUtilTests.cs
+++ b/src/Elasticsearch.Net.Aws/Tests/SignUtilTests.cs
@@ -73,15 +73,19 @@ namespace Tests
         public void SignRequest_should_apply_signature_to_request()
         {
             var secretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
-            SignV4Util.SignRequest(_sampleRequest, _sampleBody, "ExampleKey", secretKey, "us-east-1", "iam");
-            var amzDate = _sampleRequest.Headers["X-Amz-Date"];
+            SignV4Util.SignRequest(_sampleRequest, _sampleBody, "ExampleKey", secretKey, "token1", "us-east-1", "iam");
 
+            var amzDate = _sampleRequest.Headers["X-Amz-Date"];
             Assert.IsNotNullOrEmpty(amzDate);
             Trace.WriteLine("X-Amz-Date: " + amzDate);
 
             var auth = _sampleRequest.Headers[HttpRequestHeader.Authorization];
             Assert.IsNotNullOrEmpty(auth);
             Trace.WriteLine("Authorize: " + auth);
+
+            var token = _sampleRequest.Headers["x-amz-security-token"];
+            Assert.IsNotNullOrEmpty(token);
+            Trace.WriteLine("Token: " + token);
         }
 
         [Test]

--- a/src/Elasticsearch.Net.Aws/Tests/Tests.csproj
+++ b/src/Elasticsearch.Net.Aws/Tests/Tests.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InstanceProfileTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SignUtilTests.cs" />
     <Compile Include="StringUtilTests.cs" />


### PR DESCRIPTION
Some organizations (like mine!) do not allow devs to use Access Keys, so I've added support for Instance Profile Credentials. 

The AWS SDK supports these, so I had a look at how they do it - basically they call a special URL at runtime to get a temporary Access Key, Secret Key and Token, and proceed as normal from there.

The key does expire eventually, so there is checking to ensure that a "fresh" set of credentials is always available.