### PR TITLE
Fix token generation when URL contains encoded characters

### DIFF
--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SignV4Util.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SignV4Util.cs
@@ -97,7 +97,7 @@ namespace Elasticsearch.Net.Aws
         {
             var path = uri.AbsolutePath;
             if (path.Length == 0) return "/";
-            return path.Replace(":", Uri.HexEscape(':'));
+            return string.Join("/", path.Split('/').Select(HttpUtility.UrlEncode));
         }
 
         private static Dictionary<string, string> GetCanonicalHeaders(this HttpWebRequest request)

--- a/src/Elasticsearch.Net.Aws/IntegrationTests/PingTests.cs
+++ b/src/Elasticsearch.Net.Aws/IntegrationTests/PingTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace IntegrationTests
 {
+    using System.IO;
+
     [TestFixture]
     public class PingTests
     {
@@ -31,6 +33,18 @@ namespace IntegrationTests
             var client = new Nest.ElasticClient(config);
             var response = client.Ping();
             Assert.AreEqual(true, response.IsValid);
+        }
+
+        [Test]
+        public void Random_encoded_url_should_work()
+        {
+            var randomString = Guid.NewGuid().ToString("N");
+            var httpConnection = new AwsHttpConnection(TestConfig.AwsSettings);
+            var pool = new SingleNodeConnectionPool(new Uri(TestConfig.Endpoint));
+            var config = new ConnectionConfiguration(pool, httpConnection);
+            var client = new ElasticLowLevelClient(config);
+            var response = client.Get<Stream>(randomString, string.Join(",", Enumerable.Repeat(randomString, 2)), randomString);
+            Assert.AreEqual(404, response.HttpStatusCode.GetValueOrDefault(-1));
         }
     }
 


### PR DESCRIPTION
- I got 403 error when I executed following query /myIndex/entity1,entity2/_search?...
After debugging and reading manuals/error messages I figured out what was happening.
If URL contains encoded characters they need to be double encoded, so URL in form
"test%2Ctest" should be transformed to "test%252Ctest". The whole URL can't be
encoded because it will lead to / character replace, hence first it needs to be split to
parts and then each part should be encoded (double encoded in fact). After that
URL should be joined together