### PR TITLE
Using AWS_SECRET_ACCESS_KEY environment variable

### DIFF
--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
@@ -25,7 +25,7 @@ namespace Elasticsearch.Net.Aws
             if (!string.IsNullOrWhiteSpace(key)) return key;
             key = ConfigurationManager.AppSettings["AWSSecretKey"];
             if (!string.IsNullOrWhiteSpace(key)) return key;
-            return Environment.GetEnvironmentVariable("AWS_SECRET_KEY");
+            return Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY");
         }
 
         private Credentials _credentials;


### PR DESCRIPTION
AWS .NET SDK v3 expects the sectret key stored under the AWS_SECRET_ACCESS_KEY environment variable,
see here: 
http://docs.aws.amazon.com/AWSSdkDocsNET/latest/V3/DeveloperGuide/net-dg-config-creds.html#using-credentials-in-an-application