### PR TITLE
Ensuring that '*' gets encoded as '%2A'

### DIFF
--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SignV4Util.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SignV4Util.cs
@@ -96,8 +96,18 @@ namespace Elasticsearch.Net.Aws
         private static string GetPath(Uri uri)
         {
             var path = uri.AbsolutePath;
-            if (path.Length == 0) return "/";
-            return string.Join("/", path.Split('/').Select(HttpUtility.UrlEncode));
+            if(path.Length == 0) return "/";
+
+            IEnumerable<string> segments = path
+                .Split('/')
+                .Select(segment =>
+                    {
+                        string escaped = HttpUtility.UrlEncode(segment);
+                        escaped = escaped.Replace("*", "%2A");
+                        return escaped;
+                    }
+                );
+            return string.Join("/", segments);
         }
 
         private static Dictionary<string, string> GetCanonicalHeaders(this HttpWebRequest request)

--- a/src/Elasticsearch.Net.Aws/IntegrationTests/PingTests.cs
+++ b/src/Elasticsearch.Net.Aws/IntegrationTests/PingTests.cs
@@ -46,6 +46,17 @@ namespace IntegrationTests
             var response = client.Get<Stream>(randomString, string.Join(",", Enumerable.Repeat(randomString, 2)), randomString);
             Assert.AreEqual(404, response.HttpStatusCode.GetValueOrDefault(-1));
         }
+
+        [Test]
+        public void Asterisk_encoded_url_should_work()
+        {
+            var httpConnection = new AwsHttpConnection(TestConfig.AwsSettings);
+            var pool = new SingleNodeConnectionPool(new Uri(TestConfig.Endpoint));
+            var config = new ConnectionConfiguration(pool, httpConnection);
+            var client = new ElasticLowLevelClient(config);
+            var response = client.Get<Stream>("index*", "type", "id");
+            Assert.AreEqual(404, response.HttpStatusCode.GetValueOrDefault(-1));
+        }
     }
 
 }


### PR DESCRIPTION
When compiled against .NET 4.6.1, Uri.EscapeDataString no longer encodes * as %2A.  As a result, the canonical request gets signed with *, while AWS expects %2A.