### PR TITLE
Feature/signer to support other sevices

### DIFF
--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/AwsHttpConnectionTests.cs
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/AwsHttpConnectionTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using Elasticsearch.Net;
+using Elasticsearch.Net.Aws;
+using NUnit.Framework;
+using Moq;
+
+namespace ElasticSearch.Net.Aws.Tests
+{
+    [TestFixture]
+    public class AwsHttpConnectionTests
+    {
+        [Test]
+        public void Requests_Should_Be_Signed()
+        {
+            // arrange
+            var data = new byte[0];
+            var signerMock = new Mock<ISigner>();
+            var target = new AwsHttpConnection(signerMock.Object);
+            var request = new RequestData(
+                HttpMethod.POST,
+                "some-path",
+                new PostData<object>(data),
+                Mock.Of<IConnectionConfigurationValues>(m =>
+                    m.QueryStringParameters == new NameValueCollection() &&
+                    m.ConnectionPool == Mock.Of<IConnectionPool>() &&
+                    m.RequestTimeout == TimeSpan.FromSeconds(5)
+                ),
+                default(IRequestParameters),
+                Mock.Of<IMemoryStreamFactory>()
+            );
+            signerMock.Setup(m => m.SignRequest(It.IsAny<IRequest>(), It.IsAny<byte[]>())).Verifiable();
+
+            // act
+            var result = target.Request<dynamic>(request);
+
+            // assert
+            signerMock.Verify(m => m.SignRequest(It.IsAny<IRequest>(), It.IsAny<byte[]>()));
+        }
+    }
+}

--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
+    <PackageReference Include="Moq" Version="4.7.10" />
     <PackageReference Include="NUnit" Version="3.5.0" />
     <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
   </ItemGroup>

--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
     <AssemblyName>ElasticSearch.Net.Aws.Tests</AssemblyName>
     <PackageId>ElasticSearch.Net.Aws.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -17,13 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.10" />
-    <PackageReference Include="NUnit" Version="3.5.0" />
-    <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
+    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Elasticsearch.Net" Version="2.4.6" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
@@ -31,6 +29,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
@@ -19,10 +19,10 @@
     <PackageReference Include="Moq" Version="4.7.10" />
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="Elasticsearch.Net" Version="2.4.6" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="Elasticsearch.Net" Version="2.4.6" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/SignUtilTests.cs
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/SignUtilTests.cs
@@ -18,7 +18,7 @@ namespace Tests
         {
             var encoding = new UTF8Encoding(false);
             _sampleBody = encoding.GetBytes("Action=ListUsers&Version=2010-05-08");
-#if NETCOREAPP1_0
+#if NETCOREAPP1_1
             var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, "https://iam.amazonaws.com/");
             request.Content = new System.Net.Http.ByteArrayContent(_sampleBody);
             request.Content.Headers.TryAddWithoutValidation("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");

--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/SignUtilTests.cs
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/SignUtilTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Text;
 using Elasticsearch.Net.Aws;
 using NUnit.Framework;
+using Moq;
 
 namespace Tests
 {
@@ -32,49 +33,49 @@ namespace Tests
 #endif
         }
 
-        [Test]
-        public void GetCanonicalRequest_should_match_sample()
-        {
-            var canonicalRequest = SignV4Util.GetCanonicalRequest(_sampleRequest, _sampleBody);
-            Trace.WriteLine("=== Actual ===");
-            Trace.Write(canonicalRequest);
+        //[Test]
+        //public void GetCanonicalRequest_should_match_sample()
+        //{
+        //    var canonicalRequest = SignV4Util.GetCanonicalRequest(_sampleRequest, _sampleBody);
+        //    Trace.WriteLine("=== Actual ===");
+        //    Trace.Write(canonicalRequest);
 
-            const string expected = "POST\n/\n\ncontent-type:application/x-www-form-urlencoded; charset=utf-8\nhost:iam.amazonaws.com\nx-amz-date:20110909T233600Z\n\ncontent-type;host;x-amz-date\nb6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2";
-            Trace.WriteLine("=== Expected ===");
-            Trace.Write(expected);
+        //    const string expected = "POST\n/\n\ncontent-type:application/x-www-form-urlencoded; charset=utf-8\nhost:iam.amazonaws.com\nx-amz-date:20110909T233600Z\n\ncontent-type;host;x-amz-date\nb6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2";
+        //    Trace.WriteLine("=== Expected ===");
+        //    Trace.Write(expected);
 
-            Assert.AreEqual(expected, canonicalRequest);
-        }
+        //    Assert.AreEqual(expected, canonicalRequest);
+        //}
 
-        [Test]
-        public void GetStringToSign_should_match_sample()
-        {
-            var stringToSign = SignV4Util.GetStringToSign(_sampleRequest, _sampleBody, "us-east-1", "iam");
-            Trace.WriteLine("=== Actual ===");
-            Trace.Write(stringToSign);
+        //[Test]
+        //public void GetStringToSign_should_match_sample()
+        //{
+        //    var stringToSign = SignV4Util.GetStringToSign(_sampleRequest, _sampleBody, "us-east-1", "iam");
+        //    Trace.WriteLine("=== Actual ===");
+        //    Trace.Write(stringToSign);
 
-            const string expected = "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/iam/aws4_request\n3511de7e95d28ecd39e9513b642aee07e54f4941150d8df8bf94b328ef7e55e2";
-            Trace.WriteLine("=== Expected ===");
-            Trace.Write(expected);
+        //    const string expected = "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/iam/aws4_request\n3511de7e95d28ecd39e9513b642aee07e54f4941150d8df8bf94b328ef7e55e2";
+        //    Trace.WriteLine("=== Expected ===");
+        //    Trace.Write(expected);
 
-            Assert.AreEqual(expected, stringToSign);
-        }
+        //    Assert.AreEqual(expected, stringToSign);
+        //}
 
-        [Test]
-        public void GetSigningKey_should_match_sample()
-        {
-            // sample comes from - http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
-            var secretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
-            var date = "20120215";
-            var region = "us-east-1";
-            var service = "iam";
-            var expectedSigningKey = "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d";
-            var actualSigningKeyBytes = SignV4Util.GetSigningKey(secretKey, date, region, service);
-            var actualSigningKey = BitConverter.ToString(actualSigningKeyBytes).Replace("-", "").ToLowerInvariant();
-            Trace.WriteLine("Expected: " + expectedSigningKey);
-            Trace.WriteLine("Actual:   " + actualSigningKey);
-            Assert.AreEqual(expectedSigningKey, actualSigningKey);
-        }
+        //[Test]
+        //public void GetSigningKey_should_match_sample()
+        //{
+        //    // sample comes from - http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
+        //    var secretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        //    var date = "20120215";
+        //    var region = "us-east-1";
+        //    var service = "iam";
+        //    var expectedSigningKey = "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d";
+        //    var actualSigningKeyBytes = SignV4Util.GetSigningKey(secretKey, date, region, service);
+        //    var actualSigningKey = BitConverter.ToString(actualSigningKeyBytes).Replace("-", "").ToLowerInvariant();
+        //    Trace.WriteLine("Expected: " + expectedSigningKey);
+        //    Trace.WriteLine("Actual:   " + actualSigningKey);
+        //    Assert.AreEqual(expectedSigningKey, actualSigningKey);
+        //}
 
         [Test]
         public void SignRequest_should_apply_signature_to_request()
@@ -85,7 +86,9 @@ namespace Tests
                 SecretKey =  "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
                 Token = "token1",
             };
-            SignV4Util.SignRequest(_sampleRequest, _sampleBody, creds, "us-east-1", "iam");
+            var target = new AwsV4Signer("us-east-1", "iam", Mock.Of<ICredentialsProvider>(m => m.GetCredentials() == creds));
+
+            target.SignRequest(_sampleRequest, _sampleBody);
 
             var amzDate = _sampleRequest.Headers.XAmzDate;
             Assert.False(String.IsNullOrEmpty(amzDate));

--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/SignUtilTests.cs
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/SignUtilTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Text;
+using Elasticsearch.Net;
 using Elasticsearch.Net.Aws;
 using NUnit.Framework;
 using Moq;
@@ -22,85 +23,40 @@ namespace Tests
             var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, "https://iam.amazonaws.com/");
             request.Content = new System.Net.Http.ByteArrayContent(_sampleBody);
             request.Content.Headers.TryAddWithoutValidation("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
-            request.Headers.TryAddWithoutValidation("X-Amz-Date", "20110909T233600Z");
             _sampleRequest = new HttpRequestMessageAdapter(request);
 #elif NET451
             var request = System.Net.WebRequest.CreateHttp("https://iam.amazonaws.com/");
             request.Method = "POST";
             request.ContentType = "application/x-www-form-urlencoded; charset=utf-8";
-            request.Headers["X-Amz-Date"] = "20110909T233600Z";
             _sampleRequest = new HttpWebRequestAdapter(request);
 #endif
         }
 
-        //[Test]
-        //public void GetCanonicalRequest_should_match_sample()
-        //{
-        //    var canonicalRequest = SignV4Util.GetCanonicalRequest(_sampleRequest, _sampleBody);
-        //    Trace.WriteLine("=== Actual ===");
-        //    Trace.Write(canonicalRequest);
-
-        //    const string expected = "POST\n/\n\ncontent-type:application/x-www-form-urlencoded; charset=utf-8\nhost:iam.amazonaws.com\nx-amz-date:20110909T233600Z\n\ncontent-type;host;x-amz-date\nb6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2";
-        //    Trace.WriteLine("=== Expected ===");
-        //    Trace.Write(expected);
-
-        //    Assert.AreEqual(expected, canonicalRequest);
-        //}
-
-        //[Test]
-        //public void GetStringToSign_should_match_sample()
-        //{
-        //    var stringToSign = SignV4Util.GetStringToSign(_sampleRequest, _sampleBody, "us-east-1", "iam");
-        //    Trace.WriteLine("=== Actual ===");
-        //    Trace.Write(stringToSign);
-
-        //    const string expected = "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/iam/aws4_request\n3511de7e95d28ecd39e9513b642aee07e54f4941150d8df8bf94b328ef7e55e2";
-        //    Trace.WriteLine("=== Expected ===");
-        //    Trace.Write(expected);
-
-        //    Assert.AreEqual(expected, stringToSign);
-        //}
-
-        //[Test]
-        //public void GetSigningKey_should_match_sample()
-        //{
-        //    // sample comes from - http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
-        //    var secretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
-        //    var date = "20120215";
-        //    var region = "us-east-1";
-        //    var service = "iam";
-        //    var expectedSigningKey = "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d";
-        //    var actualSigningKeyBytes = SignV4Util.GetSigningKey(secretKey, date, region, service);
-        //    var actualSigningKey = BitConverter.ToString(actualSigningKeyBytes).Replace("-", "").ToLowerInvariant();
-        //    Trace.WriteLine("Expected: " + expectedSigningKey);
-        //    Trace.WriteLine("Actual:   " + actualSigningKey);
-        //    Assert.AreEqual(expectedSigningKey, actualSigningKey);
-        //}
-
-        [Test]
-        public void SignRequest_should_apply_signature_to_request()
+        [TestCase("us-east-1", "iam", "2017-01-01", "ExampleKey", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "token1", "9471c6bd5c29dcf200bfe3800ce56d2256fb9a20fd4ee0a46d1a75997d96f494")]
+        [TestCase("eu-west-1", "execute-api", "2017-05-08T16:35:25", "Some-other-key", "oL/fZjFyYDbNk8HLDtezQutb6Bvj81d/SjJdOjsO", "token2", "f93d91cff77bac6e97dbec26504e8c2b8bc218d61ee8191341aa1d7851c840c1")]
+        public void SignRequest_should_apply_signature_to_request(string region, string service, string dateTimeStr, string accessKey, string secretKey, string token, string expectedSignature)
         {
-            var creds = new AwsCredentials
-            {
-                AccessKey = "ExampleKey",
-                SecretKey =  "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-                Token = "token1",
-            };
-            var target = new AwsV4Signer("us-east-1", "iam", Mock.Of<ICredentialsProvider>(m => m.GetCredentials() == creds));
+            var dateTime = DateTime.Parse(dateTimeStr);
+            var target = new AwsV4Signer(
+                region, 
+                service, 
+                Mock.Of<ICredentialsProvider>(m => m.GetCredentials() == new AwsCredentials { AccessKey = accessKey, SecretKey = secretKey, Token = token }),
+                Mock.Of<IDateTimeProvider>(m => m.Now() == dateTime)
+            );
 
             target.SignRequest(_sampleRequest, _sampleBody);
 
-            var amzDate = _sampleRequest.Headers.XAmzDate;
-            Assert.False(String.IsNullOrEmpty(amzDate));
-            Trace.WriteLine("X-Amz-Date: " + amzDate);
+            Assert.AreEqual(dateTime.ToString("yyyyMMddTHHmmssZ"), _sampleRequest.Headers.XAmzDate);
+            Trace.WriteLine("X-Amz-Date: " + _sampleRequest.Headers.XAmzDate);
 
-            var auth = _sampleRequest.Headers.Authorization;
-            Assert.False(String.IsNullOrEmpty(auth));
-            Trace.WriteLine("Authorize: " + auth);
+            Assert.AreEqual(
+                $"AWS4-HMAC-SHA256 Credential={accessKey}/{dateTime:yyyyMMdd}/{region}/{service}/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature={expectedSignature}", 
+                _sampleRequest.Headers.Authorization
+            );
+            Trace.WriteLine("Authorize: " + _sampleRequest.Headers.Authorization);
 
-            var token = _sampleRequest.Headers.XAmzSecurityToken;
-            Assert.False(String.IsNullOrEmpty(token));
-            Trace.WriteLine("Token: " + token);
+            Assert.AreEqual(token, _sampleRequest.Headers.XAmzSecurityToken);
+            Trace.WriteLine("Token: " + _sampleRequest.Headers.XAmzSecurityToken);
         }
 
         [Test]

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
@@ -16,7 +16,7 @@ namespace Elasticsearch.Net.Aws
         /// Initializes a new instance of the AwsHttpConnection class with the specified AccessKey, SecretKey and Token.
         /// </summary>
         /// <param name="awsSettings">AWS specific settings required for signing requests.</param>
-        [Obsolete("Use AwsHttpConnection(ISigner signer)")]
+        [Obsolete("Use AwsHttpConnection(string region, ICredentialsProvider credentialsProvider)")]
         public AwsHttpConnection(AwsSettings awsSettings)
             : this(
                   awsSettings.Region, 
@@ -29,7 +29,7 @@ namespace Elasticsearch.Net.Aws
         /// Initializes a new instance of the AwsHttpConnection class with credentials from the Instance Profile service
         /// </summary>
         /// <param name="region">AWS region</param>
-        [Obsolete("Use AwsHttpConnection(ISigner signer)")]
+        [Obsolete("Use AwsHttpConnection(string region, ICredentialsProvider credentialsProvider)")]
         public AwsHttpConnection(string region)
             : this(region, CredentialChainProvider.Default)
         {
@@ -41,7 +41,6 @@ namespace Elasticsearch.Net.Aws
         /// </summary>
         /// <param name="region">AWS region</param>
         /// <param name="credentialsProvider">The credentials provider.</param>
-        [Obsolete("Use AwsHttpConnection(ISigner signer)")]
         public AwsHttpConnection(string region, ICredentialsProvider credentialsProvider)
             : this(new AwsV4Signer(region, "es", credentialsProvider))
         {

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
+using Elasticsearch.Net;
 
 namespace Elasticsearch.Net.Aws
 {
@@ -42,7 +43,7 @@ namespace Elasticsearch.Net.Aws
         /// <param name="credentialsProvider">The credentials provider.</param>
         [Obsolete("Use AwsHttpConnection(ISigner signer)")]
         public AwsHttpConnection(string region, ICredentialsProvider credentialsProvider)
-            : this(new AwsV4Signer(region, "es", credentialsProvider))
+            : this(new AwsV4Signer(region, "es", credentialsProvider, DateTimeProvider.Default))
         {
         }
 

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsHttpConnection.cs
@@ -43,7 +43,7 @@ namespace Elasticsearch.Net.Aws
         /// <param name="credentialsProvider">The credentials provider.</param>
         [Obsolete("Use AwsHttpConnection(ISigner signer)")]
         public AwsHttpConnection(string region, ICredentialsProvider credentialsProvider)
-            : this(new AwsV4Signer(region, "es", credentialsProvider, DateTimeProvider.Default))
+            : this(new AwsV4Signer(region, "es", credentialsProvider))
         {
         }
 

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsV4Signer.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsV4Signer.cs
@@ -23,6 +23,11 @@ namespace Elasticsearch.Net.Aws
         private readonly byte[] _emptyBytes = new byte[0];
         private readonly UTF8Encoding _encoding = new UTF8Encoding(false);
 
+        public AwsV4Signer(string region, string service, ICredentialsProvider credentialsProvider)
+            : this(region, service, credentialsProvider, DateTimeProvider.Default)
+        {
+        }
+
         public AwsV4Signer(string region, string service, ICredentialsProvider credentialsProvider, IDateTimeProvider dateTimeProvider)
         {
             _region = !String.IsNullOrWhiteSpace(region) ? region.ToLowerInvariant() : throw new ArgumentNullException(nameof(region));

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsV4Signer.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/AwsV4Signer.cs
@@ -18,20 +18,22 @@ namespace Elasticsearch.Net.Aws
         private readonly string _region;
         private readonly string _service;
         private readonly ICredentialsProvider _credentialsProvider;
+        private readonly IDateTimeProvider _dateTimeProvider;
         private readonly char[] _datePartSplitChars = { 'T' };
         private readonly byte[] _emptyBytes = new byte[0];
         private readonly UTF8Encoding _encoding = new UTF8Encoding(false);
 
-        public AwsV4Signer(string region, string service, ICredentialsProvider credentialsProvider)
+        public AwsV4Signer(string region, string service, ICredentialsProvider credentialsProvider, IDateTimeProvider dateTimeProvider)
         {
             _region = !String.IsNullOrWhiteSpace(region) ? region.ToLowerInvariant() : throw new ArgumentNullException(nameof(region));
             _service = !String.IsNullOrWhiteSpace(service) ? service : throw new ArgumentNullException(nameof(service));
             _credentialsProvider = credentialsProvider ?? throw new ArgumentNullException(nameof(credentialsProvider));
+            _dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));
         }
 
         public void SignRequest(IRequest request, byte[] body)
         {
-            var date = DateTime.UtcNow;
+            var date = _dateTimeProvider.Now();
             var dateStamp = date.ToString("yyyyMMdd");
             var amzDate = date.ToString("yyyyMMddTHHmmssZ");
             var credentials = _credentialsProvider.GetCredentials();

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Credentials/AwsCredentials.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Credentials/AwsCredentials.cs
@@ -25,5 +25,7 @@ namespace Elasticsearch.Net.Aws
         /// Gets or sets the security token.
         /// </summary>
         public string Token { get; set; }
+
+        public bool HasCredentials() => !String.IsNullOrWhiteSpace(AccessKey) && !String.IsNullOrWhiteSpace(SecretKey);
     }
 }

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Credentials/CredentialProviderExtensions.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Credentials/CredentialProviderExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Elasticsearch.Net;
 
 namespace Elasticsearch.Net.Aws
 {
@@ -19,7 +20,7 @@ namespace Elasticsearch.Net.Aws
         internal static void Sign(this ICredentialsProvider credentialsProvider, IRequest request, byte[] body)
         {
             var regionService = ExtractRegionAndService(request.RequestUri);
-            var signer = new AwsV4Signer(regionService.Item1, regionService.Item2, credentialsProvider);
+            var signer = new AwsV4Signer(regionService.Item1, regionService.Item2, credentialsProvider, DateTimeProvider.Default);
             signer.SignRequest(request, body);
         }
 

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Credentials/CredentialProviderExtensions.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Credentials/CredentialProviderExtensions.cs
@@ -18,13 +18,9 @@ namespace Elasticsearch.Net.Aws
 
         internal static void Sign(this ICredentialsProvider credentialsProvider, IRequest request, byte[] body)
         {
-            var credentials = credentialsProvider.GetCredentials();
-            if (credentials == null)
-            {
-                throw new Exception("Unable to retrieve credentials.");
-            }
             var regionService = ExtractRegionAndService(request.RequestUri);
-            SignV4Util.SignRequest(request, body, credentials, regionService.Item1, regionService.Item2);
+            var signer = new AwsV4Signer(regionService.Item1, regionService.Item2, credentialsProvider);
+            signer.SignRequest(request, body);
         }
 
         static readonly Regex _regionRegex = new Regex(@"\.([\w-]+)\.([\w-]+)\.amazonaws\.com$", RegexOptions.Compiled);

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.nuspec
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Elasticsearch.Net.Aws</id>
-    <version>2.3.3</version>
+    <version>2.3.4</version>
     <title>Elasticsearch.Net.Aws</title>
     <authors>Brandon Cuff</authors>
     <licenseUrl>https://raw.githubusercontent.com/bcuff/elasticsearch-net-aws/master/LICENSE</licenseUrl>

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/IHeaders.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/IHeaders.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Elasticsearch.Net.Aws
 {
-    internal interface IHeaders
+    public interface IHeaders
     {
         string XAmzDate { get; set; }
         string Authorization { get; set; }

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/IRequest.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/IRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Elasticsearch.Net.Aws
 {
-    internal interface IRequest
+    public interface IRequest
     {
         IHeaders Headers { get; }
         string Method { get; }

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/ISigner.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/ISigner.cs
@@ -1,0 +1,10 @@
+﻿namespace Elasticsearch.Net.Aws
+{
+    /// <summary>
+    /// Interface represent an abstraction of request signer.
+    /// </summary>
+    public interface ISigner
+    {
+        void SignRequest(IRequest request, byte[] data);
+    }
+}


### PR DESCRIPTION
AwsHttpConnection now takes signer abstraction dependency as a ISigner constructor parameter. All SignV4Util static methods moved as private methods of Aws4Signer class which implements ISigner. Improved encapsulation and testability. 