### PR TITLE
Upgrade to v6 of ElasticSearch, NEST and ElasticSearch.Net

### DIFF
--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.IntegrationTests/ElasticSearch.Net.Aws.IntegrationTests.csproj
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.IntegrationTests/ElasticSearch.Net.Aws.IntegrationTests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
     <PackageReference Include="NUnit" Version="3.7.*" />
-    <PackageReference Include="NEST" Version="2.4.6" />
+    <PackageReference Include="NEST" Version="6.0.0-rc1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>

--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.IntegrationTests/PingTests.cs
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.IntegrationTests/PingTests.cs
@@ -1,19 +1,61 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Elasticsearch.Net.Aws;
 using NUnit.Framework;
 
 namespace IntegrationTests
 {
-    using System.IO;
-
     [TestFixture]
     public class PingTests
     {
+        public class TestDoc
+        {
+            public string Id { get; set; }
+            public string Something { get; set; }
+        }
+        private class Response : IElasticsearchResponse
+        {
+            public bool TryGetServerErrorReason(out string reason)
+            {
+                reason = "error";
+                return true;
+            }
+
+            public IApiCallDetails ApiCall { get; set; }
+        }
+
         private static string Region => TestConfig.AwsSettings.Region;
         private static ICredentialsProvider Credentials => new StaticCredentialsProvider(TestConfig.AwsSettings);
+
+
+        [Test]
+        public async Task Indexing_documents_should_work()
+        {
+            var httpConnection = new AwsHttpConnection(Region, Credentials);
+            var pool = new SingleNodeConnectionPool(new Uri(TestConfig.Endpoint));
+            var config = new Nest.ConnectionSettings(pool, httpConnection);
+            var client = new Nest.ElasticClient(config);
+            var indexName = "integration-test";
+            var existsResponse = await client.IndexExistsAsync(indexName);
+            if (existsResponse.Exists)
+            {
+                await client.DeleteIndexAsync(indexName);
+            }
+            var createIndexResponse = await client.CreateIndexAsync(indexName);
+            Assert.IsTrue(createIndexResponse.Acknowledged);
+
+            var doc = new TestDoc { Id = "123", Something = "unit-test" };
+            var indexResponse = await client.IndexAsync(doc, i => i.Id(doc.Id).Index(indexName));
+            Assert.AreEqual(Nest.Result.Created, indexResponse.Result);
+            var queryResponse = await client.SearchAsync<TestDoc>(s => s.Index(indexName).Query(q => q.Ids(id => id.Values(doc.Id))));
+            Assert.AreEqual(queryResponse.Documents.Count, 1);
+            Assert.AreEqual(queryResponse.Documents.First().Id, doc.Id);
+            Assert.AreEqual(queryResponse.Documents.First().Something, doc.Something);
+            var deleteIndexResonse = await client.DeleteIndexAsync(indexName);
+            Assert.IsTrue(deleteIndexResonse.Acknowledged);
+        }
         [Test]
         public void Ping_should_work()
         {
@@ -21,8 +63,8 @@ namespace IntegrationTests
             var pool = new SingleNodeConnectionPool(new Uri(TestConfig.Endpoint));
             var config = new ConnectionConfiguration(pool, httpConnection);
             var client = new ElasticLowLevelClient(config);
-            var response = client.Ping<object>();
-            Assert.AreEqual(200, response.HttpStatusCode.GetValueOrDefault(-1));
+            var response = client.Ping<Response>();
+            Assert.AreEqual(200, response.ApiCall.HttpStatusCode.GetValueOrDefault(-1));
 
         }
 
@@ -36,7 +78,7 @@ namespace IntegrationTests
             var response = client.Ping();
             Assert.AreEqual(true, response.IsValid);
         }
-
+        
         [Test]
         public void Random_encoded_url_should_work()
         {
@@ -45,8 +87,8 @@ namespace IntegrationTests
             var pool = new SingleNodeConnectionPool(new Uri(TestConfig.Endpoint));
             var config = new ConnectionConfiguration(pool, httpConnection);
             var client = new ElasticLowLevelClient(config);
-            var response = client.Get<Stream>(randomString, string.Join(",", Enumerable.Repeat(randomString, 2)), randomString);
-            Assert.AreEqual(404, response.HttpStatusCode.GetValueOrDefault(-1));
+            var response = client.Get<Response>(randomString, string.Join(",", Enumerable.Repeat(randomString, 2)), randomString);
+            Assert.AreEqual(404, response.ApiCall.HttpStatusCode.GetValueOrDefault(-1));
         }
 
         [Test]
@@ -56,8 +98,8 @@ namespace IntegrationTests
             var pool = new SingleNodeConnectionPool(new Uri(TestConfig.Endpoint));
             var config = new ConnectionConfiguration(pool, httpConnection);
             var client = new ElasticLowLevelClient(config);
-            var response = client.Get<Stream>("index*", "type", "id");
-            Assert.AreEqual(404, response.HttpStatusCode.GetValueOrDefault(-1));
+            var response = client.Get<Response>("index*", "type", "id");
+            Assert.AreEqual(404, response.ApiCall.HttpStatusCode.GetValueOrDefault(-1));
         }
     }
 

--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
@@ -19,13 +19,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
     <PackageReference Include="NUnit" Version="3.7.*" />
-    <PackageReference Include="NEST" Version="2.4.6" />
+    <PackageReference Include="NEST" Version="6.0.0-rc1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="Elasticsearch.Net" Version="2.4.6" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.csproj
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <VersionPrefix>2.3.4</VersionPrefix>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <AssemblyName>Elasticsearch.Net.Aws</AssemblyName>
     <PackageId>Elasticsearch.Net.Aws</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -18,9 +17,9 @@
     <PackageReleaseNotes>Support for named instance profiles</PackageReleaseNotes>
     <PackageTags>elasticsearch elastic search aws amazon</PackageTags>
     <RepositoryUrl>https://github.com/bcuff/elasticsearch-net-aws</RepositoryUrl>
-    <AssemblyVersion>2.4.0.0</AssemblyVersion>
-    <FileVersion>2.4.0.0</FileVersion>
-    <Version>2.4.0</Version>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
+    <FileVersion>3.0.0.0</FileVersion>
+    <Version>3.0.0-beta1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -30,8 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.17.9" />
-    <PackageReference Include="Elasticsearch.Net" Version="2.4.6" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.7" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.0.0-rc1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
@@ -43,8 +42,10 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.0.2" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities">
+      <Version>1.1.2</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.nuspec
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Elasticsearch.Net.Aws</id>
-    <version>2.3.7</version>
+    <version>3.0.0-beta</version>
     <title>Elasticsearch.Net.Aws</title>
     <authors>Brandon Cuff</authors>
     <licenseUrl>https://raw.githubusercontent.com/bcuff/elasticsearch-net-aws/master/LICENSE</licenseUrl>
@@ -14,17 +14,17 @@
     <tags>elasticsearch elastic search aws amazon</tags>
     <dependencies>
       <group>
-        <dependency id="Elasticsearch.Net" version="2.4.6" />
+        <dependency id="Elasticsearch.Net" version="6.0.0-rc1" />
         <dependency id="Newtonsoft.Json" version="9.0.1" />
       </group>
       <group targetFramework=".NETStandard,Version=1.3">
         <dependency id="NETStandard.Library" version="1.6.0" />
-        <dependency id="Microsoft.AspNetCore.WebUtilities" version="1.0.0" />
+        <dependency id="Microsoft.AspNetCore.WebUtilities" version="1.1.2" />
       </group>
     </dependencies>
   </metadata>
   <files>
     <file src="bin\Release\net45\Elasticsearch.Net.Aws.dll" target="lib\net45\Elasticsearch.Net.Aws.dll" />
-    <file src="bin\Release\netstandard1.3\Elasticsearch.Net.Aws.dll" target="lib\netstandard1.3\Elasticsearch.Net.Aws.dll" />
+    <file src="bin\Release\netstandard1.6\Elasticsearch.Net.Aws.dll" target="lib\netstandard1.6\Elasticsearch.Net.Aws.dll" />
   </files>
 </package>


### PR DESCRIPTION
It looks like a lot of dependencies are fairly outdated. Valid for keeping background compatibility, but it might be worth starting a separate version / branch to get onto new features.

This PR isn't fully tested, but should give an idea whoever wants to implement #33. I won't pursue it since I'm not going to need the feature offered in this library.