### PR TITLE
Signing with InvariantCulture, so different calendars produce good ou…

### DIFF
--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SignV4Util.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SignV4Util.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -18,8 +19,8 @@ namespace Elasticsearch.Net.Aws
         public static void SignRequest(IRequest request, byte[] body, ImmutableCredentials credentials, string region, string service)
         {
             var date = DateTime.UtcNow;
-            var dateStamp = date.ToString("yyyyMMdd");
-            var amzDate = date.ToString("yyyyMMddTHHmmssZ");
+            var dateStamp = date.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+            var amzDate = date.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
             request.Headers.XAmzDate = amzDate;
 
             var signingKey = GetSigningKey(credentials.SecretKey, dateStamp, region, service);


### PR DESCRIPTION
…tput.

For example, in Thailand they are 543 years ahead, when formatting a date using `date.ToString("yyyyMMdd")` , it will produce `25640129`. The library needs to format using the invariant culture to avoid issues with different calendars falling out of sync with AWS.

The test is not great but I've included it so the issue is easy to reproduce. To make it more elegant I would need to extract `DateTime.UtcNow` from `SignV4Util.cs` which it's quite a bigger change.