### PR TITLE
feat(signing): use new signing

### DIFF
--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.IntegrationTests/TestDocument.cs
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.IntegrationTests/TestDocument.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IntegrationTests
+{
+    public class TestDocument
+    {
+        public string Message { get; set; }
+    }
+}

--- a/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
+++ b/src/Elasticsearch.Net.Aws/ElasticSearch.Net.Aws.Tests/ElasticSearch.Net.Aws.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <AssemblyName>ElasticSearch.Net.Aws.Tests</AssemblyName>
     <PackageId>ElasticSearch.Net.Aws.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/HttpMessageHandlerExtensions.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/HttpMessageHandlerExtensions.cs
@@ -1,0 +1,45 @@
+﻿#if NETSTANDARD
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elasticsearch.Net.Aws
+{
+    internal static class HttpMessageHandlerExtensions
+    {
+        static readonly Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _sendFunc = GetSendAsync();
+
+        static Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> GetSendAsync()
+        {
+            var info = typeof(HttpMessageHandler).GetTypeInfo();
+            var q = from method in info.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    where method.Name == "SendAsync"
+                    let p = method.GetParameters()
+                    where p.Length == 2 && p[0].ParameterType == typeof(HttpRequestMessage) && p[1].ParameterType == typeof(CancellationToken)
+                    select method;
+            var sendAsyncMethod = q.FirstOrDefault();
+            if (sendAsyncMethod == null) throw new InvalidOperationException($"Unable to find SendAsync method on handler of type {nameof(HttpMessageHandler)}");
+            var handler = Expression.Parameter(typeof(HttpMessageHandler), "handler");
+            var request = Expression.Parameter(typeof(HttpRequestMessage), "request");
+            var cancellationToken = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
+            return Expression.Lambda<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>(
+                Expression.Call(handler, sendAsyncMethod, request, cancellationToken),
+                "WrappedSendAsync",
+                new[] { handler, request, cancellationToken }
+            ).Compile();
+        }
+
+        public static Task<HttpResponseMessage> SendAsync(this HttpMessageHandler handler, HttpRequestMessage request, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // this reflection is necessary to bypass the "protected internal" access modifiers
+            // on HttpMessageHandler.SendAsync
+            // unfortunately I haven't found a good way around doing this.
+            return _sendFunc(handler, request, cancellationToken);
+        }
+    }
+}
+#endif

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/IRequest.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/IRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Elasticsearch.Net.Aws
 {
@@ -7,5 +8,7 @@ namespace Elasticsearch.Net.Aws
         IHeaders Headers { get; }
         string Method { get; }
         Uri RequestUri { get; }
+        Task PrepareForSigningAsync();
+        byte[] Content { get; }
     }
 }

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SigningHttpMessageHandler.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SigningHttpMessageHandler.cs
@@ -1,0 +1,40 @@
+﻿#if NETSTANDARD
+using Amazon;
+using Amazon.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elasticsearch.Net.Aws
+{
+    class SigningHttpMessageHandler : HttpClientHandler
+    {
+        readonly AWSCredentials _credentials;
+        readonly RegionEndpoint _region;
+        readonly HttpMessageHandler _innerHandler;
+
+        public SigningHttpMessageHandler(AWSCredentials credentials, RegionEndpoint region, HttpMessageHandler innerHandler)
+        {
+            _credentials = credentials;
+            _region = region;
+            _innerHandler = innerHandler;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var credentials = await _credentials.GetCredentialsAsync().ConfigureAwait(false);
+            await SignV4Util.SignRequestAsync(new HttpRequestMessageAdapter(request), credentials, _region.SystemName, "es").ConfigureAwait(false);
+            return await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) _innerHandler.Dispose();
+            base.Dispose();
+        }
+    }
+}
+#endif

--- a/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SigningHttpMessageHandler.cs
+++ b/src/Elasticsearch.Net.Aws/Elasticsearch.Net.Aws/SigningHttpMessageHandler.cs
@@ -15,6 +15,7 @@ namespace Elasticsearch.Net.Aws
         readonly AWSCredentials _credentials;
         readonly RegionEndpoint _region;
         readonly HttpMessageHandler _innerHandler;
+        bool _innerHandlerDisposed;
 
         public SigningHttpMessageHandler(AWSCredentials credentials, RegionEndpoint region, HttpMessageHandler innerHandler)
         {
@@ -32,7 +33,14 @@ namespace Elasticsearch.Net.Aws
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing) _innerHandler.Dispose();
+            if (!_innerHandlerDisposed)
+            {
+                if (disposing)
+                {
+                    _innerHandler.Dispose();
+                }
+                _innerHandlerDisposed = true;
+            }
             base.Dispose();
         }
     }


### PR DESCRIPTION
Use new signing technique that allows for all http headers
to be accounted for correctly. This may fix signing when
http compression is turned on.